### PR TITLE
Added link to another Python + economics resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ We chose these papers to replicate because (a) they were recently published in g
 - [Python for Econometrics, Statistics and Numerical Analysis](https://www.kevinsheppard.com/teaching/python/notes/) (Kevin Sheppard)
 - [PyEcon](https://pyecon.org)
 - [Python Data Science Handbook](https://jakevdp.github.io/PythonDataScienceHandbook/)
+- [Coding for Economists](https://aeturrell.github.io/coding-for-economists)
 
 ### Where Can I Learn More About Julia?
 


### PR DESCRIPTION
Hi there,

This looks great! Just adding a link to https://aeturrell.github.io/coding-for-economists in your resources for learning Python list.